### PR TITLE
Fix Wrapper variable type in wrapWithSimpleWrapper

### DIFF
--- a/src/wrapWithSimpleWrapper.jsx
+++ b/src/wrapWithSimpleWrapper.jsx
@@ -9,9 +9,7 @@ const defaultProps = {
   children: undefined,
 };
 
-const Wrapper = Object.assign(function SimpleSFCWrapper({ children }) {
-  return children;
-}, { propTypes, defaultProps });
+const Wrapper = Object.assign(({ children }) => children, { propTypes, defaultProps });
 
 export default function wrap(element) {
   return <Wrapper>{element}</Wrapper>;

--- a/src/wrapWithSimpleWrapper.jsx
+++ b/src/wrapWithSimpleWrapper.jsx
@@ -9,8 +9,7 @@ const defaultProps = {
   children: undefined,
 };
 
-// eslint-disable-next-line prefer-arrow-callback
-const Wrapper = () => Object.assign(function SimpleSFCWrapper({ children }) {
+const Wrapper = Object.assign(function SimpleSFCWrapper({ children }) {
   return children;
 }, { propTypes, defaultProps });
 


### PR DESCRIPTION
👋 We had several tests failing while using `@wojtekmaj/enzyme-adapter-react-17` and I tracked them down to this bug. In https://github.com/wojtekmaj/enzyme-adapter-utils/commit/2e0927b455ad8c93cff8df4c618bde8b85f1a206 the `Wrapper` variable was changed so that it now returns a function that returns a component instead of just being a component.

Thanks!

