### PR TITLE
Allow usage with react 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,12 +49,12 @@
     "husky": "^7.0.0",
     "prettier": "^2.5.0",
     "pretty-quick": "^3.1.0",
-    "react": "^17.0.0",
-    "react-dom": "^17.0.0",
+    "react": "^17.0.0 || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0",
     "rimraf": "^3.0.0"
   },
   "peerDependencies": {
-    "react": "^17.0.0-0"
+    "react": "^17.0.0 || ^18.0.0"
   },
   "resolutions": {
     "semver@7.0.0": "^7.0.0"


### PR DESCRIPTION
The upgrade doesn't provide much breaking changes so I think this should work out of the box.

Upgrade: https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html